### PR TITLE
feat: Add JWT Login frame

### DIFF
--- a/src/main/java/com/example/cardmonkey/controller/AuthController.java
+++ b/src/main/java/com/example/cardmonkey/controller/AuthController.java
@@ -1,0 +1,62 @@
+package com.example.cardmonkey.controller;
+
+import com.example.cardmonkey.service.MemberService;
+import com.example.cardmonkey.entity.Token;
+import com.example.cardmonkey.repository.TokenRepository;
+import com.example.cardmonkey.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final MemberService memberService;
+    private final TokenRepository tokenRepository;
+
+    @PostMapping("/signup")
+    public String signup(){
+        return null;
+    }
+
+    /* 회원가입 예시코드 =======================
+    @PostMapping("/sign-up")
+    public String signUp(UserDTO addUserDto) {
+        userService.signup(addUserDto);
+        return "success";
+    }
+    ==================================== */
+
+    @PostMapping("signin")
+    public String signin(){
+        return null;
+    }
+
+    /* 로그인 예시코드 =========================
+    @PostMapping("/sign-in")
+    public String signIn(UserDTO loginUserDto) {
+        String loginUserResponse = userService.signin(loginUserDto);
+        return loginUserResponse;
+    }
+    ==================================== */
+
+
+    /* 권한확인 예시코드 ==========================
+    @GetMapping("/hello")
+    @PreAuthorize("hasAnyRole('USER')") // USER 권한만 호출 가능
+    public String hello(@AuthenticationPrincipal UserDTO user) {
+        return user.getEmail() + ", 안녕하세요!";
+    }
+    ==================================== */
+
+    @PostMapping("/logout")
+    public String logout(@RequestHeader(name="Authorization") String header){
+        tokenRepository.save(Token.builder().token(header).build());
+        return "success";
+    }
+}

--- a/src/main/java/com/example/cardmonkey/dto/MemberDTO.java
+++ b/src/main/java/com/example/cardmonkey/dto/MemberDTO.java
@@ -1,0 +1,46 @@
+package com.example.cardmonkey.dto;
+
+import com.example.cardmonkey.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class MemberDTO {
+
+    private String userId;
+    private String password;
+
+    public Member toEntity(){
+        return null;
+
+        /* 예시코드 =====================
+        return User.builder()
+                .email(this.email)
+                .password(this.password)
+                .build();
+         ===================== */
+    }
+
+    /* 예시코드  =====================
+    public UserDTO(Claims claims){
+        this.email=claims.get("email",String.class);
+    }
+    ===================== */
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // ROLE_USER, ROLE_ADMIN 은 정해저 있는 네이밍임, getAuthorities() 이름도 같아야함
+        // 만약 하나로 구분이 아니고 여러 개의 권한을 가져야 한다면, 아래와 닽이 쓸것
+        //return Arrays.asList(new SimpleGrantedAuthority("ROLE_USER"),new SimpleGrantedAuthority("ROLE_ADMIN"));
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_MEMBER"));
+    }
+}

--- a/src/main/java/com/example/cardmonkey/entity/Token.java
+++ b/src/main/java/com/example/cardmonkey/entity/Token.java
@@ -1,0 +1,22 @@
+package com.example.cardmonkey.entity;
+
+import lombok.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="jwt_logout")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Token {
+
+    @Id
+    @Column(name="token")
+    private String token;
+}

--- a/src/main/java/com/example/cardmonkey/jwt/JwtFilter.java
+++ b/src/main/java/com/example/cardmonkey/jwt/JwtFilter.java
@@ -1,0 +1,46 @@
+package com.example.cardmonkey.jwt;
+
+
+import com.example.cardmonkey.repository.TokenRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    //시큐리티 필터 전에 유저 권한이나 인증 관련 정보를 넘겨주는 클래스
+
+    private final JwtProvider jwtProvider;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token=request.getHeader(HttpHeaders.AUTHORIZATION); // Bearer dasdsaeqqeqew.sdsddsdsdsdsdf.eewewrerwwerwre
+
+        if(!tokenRepository.existsByToken(token)) {
+
+            Claims claims = jwtProvider.tokenToUser(token);
+            /*
+            if (claims != null) {
+                UserDTO dto = new UserDTO(claims);
+                SecurityContextHolder.getContext()
+                        .setAuthentication(new UsernamePasswordAuthenticationToken(dto, null, dto.getAuthorities()));
+            }
+             */
+        }
+        filterChain.doFilter(request,response);
+    }
+
+}

--- a/src/main/java/com/example/cardmonkey/jwt/JwtProvider.java
+++ b/src/main/java/com/example/cardmonkey/jwt/JwtProvider.java
@@ -1,0 +1,45 @@
+package com.example.cardmonkey.jwt;
+
+import com.example.cardmonkey.entity.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+    //토큰을 발급하거나, 토큰을 유저 객체로 바꾸는 클래스
+
+    public String token(Member member){
+        Date date=new Date();
+
+        return Jwts.builder()
+                .setHeaderParam("typ","JWT")
+                .setIssuer("james")
+                .setIssuedAt(date)
+                .setExpiration(new Date(date.getTime()+3600000))
+                .claim("userId",member.getUserId())
+                .signWith(SignatureAlgorithm.HS256,"12345")
+                .compact();
+
+    }
+
+    public Claims tokenToUser(String token){ // "Bearer sdmleeweawlek.ekwekwekewrkj.enwerkjwerknrwekn"
+
+        if(token!=null) {
+            token = token.substring("Bearer".length());
+
+            return Jwts.parser()
+                    .setSigningKey("12345")
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        }else{
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/cardmonkey/repository/MemberRepository.java
+++ b/src/main/java/com/example/cardmonkey/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.example.cardmonkey.repository;
+
+import com.example.cardmonkey.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+public interface MemberRepository extends JpaRepository<Member, String> {
+
+    Optional<Member> findByUserIdAndPassword(String userId, String Password);
+
+}

--- a/src/main/java/com/example/cardmonkey/repository/TokenRepository.java
+++ b/src/main/java/com/example/cardmonkey/repository/TokenRepository.java
@@ -1,0 +1,10 @@
+package com.example.cardmonkey.repository;
+
+import com.example.cardmonkey.entity.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenRepository extends JpaRepository<Token,String> {
+
+    boolean existsByToken(String token);
+
+}

--- a/src/main/java/com/example/cardmonkey/security/SecurityConfig.java
+++ b/src/main/java/com/example/cardmonkey/security/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.example.cardmonkey.security;
+
+import com.example.cardmonkey.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+    private static final String[] PUBLIC_URLS = { //이 URL은 권한 검사안함
+            "/sign-up", "/sign-in" , "/index", "/js/**", "/logout"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http)throws Exception{
+
+        return http
+                .authorizeRequests()// 다음 리퀘스트에 대한 사용권한 체크
+                .mvcMatchers(PUBLIC_URLS).permitAll() // 가입 및 인증 주소는 누구나 접근가능
+                .and()
+                .authorizeRequests()// 다음 리퀘스트에 대한 사용권한 체크
+                .anyRequest().authenticated()// 그외 나머지 요청은 모두 인증된 회원만 접근 가능
+                .and()
+                .csrf().disable() // rest api이므로 csrf 보안이 필요없으므로 disable처리
+                .httpBasic().disable() // 기본설정 사용안함. 기본설정은 비인증시 로그인폼 화면으로 리다이렉트 된다.
+                .formLogin().loginPage("/index").permitAll()//로그인 기본 url 설정
+                .and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // jwt token으로 인증할것이므로 세션필요없으므로 생성안함.
+                .and()
+                .addFilterBefore(
+                        jwtFilter,
+                        UsernamePasswordAuthenticationFilter.class).build();
+        //인증을 처리하는 기본필터 UsernamePasswordAuthenticationFilter 대신 별도의 인증 로직을 가진 필터를 생성하고 사용하고 싶을 때 아래와 같이 필터를 등록하고 사용
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() { //시큐리티 filter 제외, 그러나 OncePerRequestFilter는 시큐리티 필터가 아니라서 로직실행
+        return (web) -> web.ignoring().mvcMatchers(PUBLIC_URLS);
+    }
+
+
+}

--- a/src/main/java/com/example/cardmonkey/service/MemberService.java
+++ b/src/main/java/com/example/cardmonkey/service/MemberService.java
@@ -1,0 +1,40 @@
+package com.example.cardmonkey.service;
+
+import com.example.cardmonkey.jwt.JwtProvider;
+import com.example.cardmonkey.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    public String signup(){
+        return null;
+    }
+    /* 예시코드 ===============================
+    public String signup(UserDTO userDTO){
+        userRepository.save(userDTO.toEntity());
+        return "success";
+    }
+     =============================== */
+
+    public String signin(){
+        return null;
+    }
+    /* 예시코드 ===============================
+    public String signin(UserDTO userDTO){
+        Optional<User> loggedIn=userRepository.findByEmailAndPassword(userDTO.getEmail(),userDTO.getPassword());
+        try{
+            User user=loggedIn.get();
+            return jwtProvider.token(user);
+        }catch(NoSuchElementException e){
+            return "failed";
+        }
+    }
+     =============================== */
+
+}


### PR DESCRIPTION
## Motivation

Jwt 로그인/로그아웃 관련 필요파일 추가
[searpier : jwt-again Repo](https://github.com/searpier/jwt-again)


## Key Changes

* Add AuthController : 로그인/로그아웃/회원가입 관련 컨트롤러
* Add MemberDTO : 로그인/로그아웃 기능만을 위한 MemberDTO 구성
* Add Token Entity : 만료된 token 정보를 저장하기 위한 Entity 구성
* Add JwtFillter/JwtProvider : Jwt 필터 & 토큰부여 기능
* Add MemberRepository : 로그인/로그아웃 관련 Member JPA 함수추가
* Add TokenRepository : 만료된 토큰관련 JPA 함수추가
* SecurityConfig : Jwt 설정파일 추가


## To reviewers

* 기존 User로 설정되어있는 내용을 Member로 교체
* 컨트롤러 파일에 기존코드는 주석처리, 작성해되는 메소드 틀만 추가
